### PR TITLE
Fix bug with connection being removed every ~1000 requests

### DIFF
--- a/asyncpgsa/__init__.py
+++ b/asyncpgsa/__init__.py
@@ -2,6 +2,6 @@ from .pool import create_pool
 from .pgsingleton import PG
 from .connection import compile_query
 
-__version__ = '0.4.1'
+__version__ = '0.5.0'
 pg = PG()
 

--- a/asyncpgsa/connection.py
+++ b/asyncpgsa/connection.py
@@ -39,24 +39,14 @@ def compile_query(query, dialect=_dialect):
 
 
 class SAConnection:
-    __slots__ = ('connection', 'pool')
+    __slots__ = ('connection',)
 
     def __init__(self, connection_: connection):
         self.connection = connection_
-        self.pool = None
 
     def __getattr__(self, attr, *args, **kwargs):
         # getattr is only called when attr is NOT found
         return getattr(self.connection, attr)
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        if self.pool:
-            await self.pool.release(self)
-        else:
-            await self.close()
 
     async def execute(self, script, *args, **kwargs) -> str:
         script, params = compile_query(script)

--- a/asyncpgsa/pool.py
+++ b/asyncpgsa/pool.py
@@ -7,8 +7,9 @@ from .connection import SAConnection
 class SAPool(Pool):
     async def _new_connection(self, timeout=None):
         con = await super()._new_connection()
+        self._connections.remove(con)
         con = SAConnection.from_connection(con)
-        con.pool = self
+        self._connections.add(con)
         return con
 
     def transaction(self, **kwargs):

--- a/asyncpgsa/testing/mockconnection.py
+++ b/asyncpgsa/testing/mockconnection.py
@@ -1,6 +1,5 @@
 from asyncio import Queue
 
-from asyncpgsa import compile_query
 from .mockpreparedstmt import MockPreparedStatement
 
 
@@ -19,12 +18,6 @@ class MockConnection:
 
         raise Exception('Sorry, {} doesnt exist yet. '
                         'Consider making a PR.'.format(item))
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        pass
 
     async def prepare(self, query, *, timeout=None):
         return MockPreparedStatement(self, query, None)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='asyncpgsa',
-    version='0.4.1',
+    version='0.5.0',
     install_requires=[
         'asyncpg',
         'sqlalchemy',


### PR DESCRIPTION
Most of the time, no issues are noticed because the connection pool recycles connections
But once in a while a connection would die, and when the pool tried to replace
a KeyError was raised because the wrong connection was in the queue.
The fix is to replace the asyncpg.connection object in the queue
with the one from asyncpgsa.connection that wraps the former