### PR TITLE
Fixes #6: Adds a debug param for printing queries

### DIFF
--- a/asyncpgsa/log.py
+++ b/asyncpgsa/log.py
@@ -1,0 +1,3 @@
+import logging
+
+query_logger = logging.getLogger('asyncpgsa.query')

--- a/asyncpgsa/pool.py
+++ b/asyncpgsa/pool.py
@@ -70,7 +70,7 @@ def create_pool(dsn=None, *,
     :return: An instance of :class:`~asyncpg.pool.Pool`.
     """
     return SAPool(dsn,
-                min_size=min_size, max_size=max_size,
-                max_queries=max_queries, loop=loop, setup=setup,
-                **connect_kwargs)
+                  min_size=min_size, max_size=max_size,
+                  max_queries=max_queries, loop=loop, setup=setup,
+                  **connect_kwargs)
 

--- a/asyncpgsa/testing/mockpgsingleton.py
+++ b/asyncpgsa/testing/mockpgsingleton.py
@@ -14,12 +14,12 @@ class MockPG:
         self.__pool = MockSAPool(connection=self.connection)
 
     def get_completed_queries(self):
-        return self.connection.connection.completed_queries
+        return self.connection._connection.completed_queries
 
     def set_database_results(self, *results):
-        self.connection.connection.results = Queue()  # reset queue
+        self.connection._connection.results = Queue()  # reset queue
         for result in results:
-            self.connection.connection.results.put_nowait(result)
+            self.connection._connection.results.put_nowait(result)
 
     def query(self, query, *args, **kwargs):
         compiled_q, compiled_args = compile_query(query)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-asyncio
+pytest-capturelog>=0.7


### PR DESCRIPTION
Fixes #6

* Adds a debug param to various components to enable printing of some debug statements, currently only the query.
* Makes the connection protected to maintain library standard

I intentionally left off the params - I could see a case for someone wanting that at some point but there is often enough info in there you may not want shown.

As a start it just prints to stdout, not sure if you would like to use the logger for users to customize or print to stderr instead. In either case, I can happily fix it.