### PR TITLE
Change from default psycopg2 dialect to pypostgresql.

### DIFF
--- a/asyncpgsa/connection.py
+++ b/asyncpgsa/connection.py
@@ -1,14 +1,14 @@
 import re
 
 from asyncpg import connection
-from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import pypostgresql
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.dml import Insert as InsertObject, Update as UpdateObject
 
 from .log import query_logger
 from .record import RecordGenerator, Record
 
-_dialect = postgresql.dialect()
+_dialect = pypostgresql.dialect()
 _dialect.implicit_returning = True
 _dialect.supports_native_enum = True
 _dialect.supports_smallserial = True  # 9.2+


### PR DESCRIPTION
This avoids incorrectly replacing the '%' operator as '%%'. Fixes #19.

This was my experiment while investigating the problem. Again, I don't know what the implications are.