### PR TITLE
Update regex for getting query

### DIFF
--- a/asyncpgsa/connection.py
+++ b/asyncpgsa/connection.py
@@ -16,7 +16,7 @@ _dialect._backslash_escapes = False
 _dialect.supports_sane_multi_rowcount = True  # psycopg 2.0.9+
 _dialect._has_native_hstore = True
 _dialect.paramstyle = 'named'
-_pattern = r':(\w+)(?:\W|)'
+_pattern = r'(?<!:):(\w+)'
 _compiled_pattern = re.compile(_pattern, re.M)
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -21,6 +21,17 @@ async def test__replace_keys():
                            '($2, $3, $4, $5, $6, $7, $8, $9, $10)'
     assert new_query[1] == [None, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
+async def test__replace_keys_colon():
+    sql = sa.text('SELECT :id, my_date::DATE FROM users')
+    params = {
+        'id': 123,
+    }
+    sql = sql.params(**params)
+
+    q, p = connection.compile_query(sql)
+    assert q == 'SELECT $1, my_date::DATE FROM users'
+    assert p == [123]
+
 async def test__get_keys():
     ids = list(range(1, 10))
     query = file_table.update() \


### PR DESCRIPTION
... parameter so ::var does not get captured with :var

This is useful now, where as ideally a fuller solution like #25 is not ready for prime time yet. But at least this would fix some of the bugs we are having now. 