### PR TITLE
Improved record type.

### DIFF
--- a/asyncpgsa/record.py
+++ b/asyncpgsa/record.py
@@ -1,10 +1,7 @@
-
+from sqlalchemy import Column
 
 class Record:
     __slots__ = ('row',)
-
-    def __str__(self):
-        return str(self.row)
 
     def __init__(self, row):
         self.row = row
@@ -13,8 +10,17 @@ class Record:
         try:
             return self.row[item]
         except KeyError:
-            raise AttributeError("'Row' object has no attribute '{}'"
-                                 .format(item))
+            try:
+                return getattr(self.row, item)
+            except AttributeError:
+                raise AttributeError("'Row' object has no attribute '{}'"
+                                     .format(item))
+
+    def __getitem__(self, key):
+        if isinstance(key, Column):
+            key = key.name
+
+        return self.row[key]
 
     def __bool__(self):
         return self.row is not None


### PR DESCRIPTION
Adds support to asyncpgsa Record type for all the methods allowed in asyncpg Record type.

This change allows to use subscript operator and SQL Alchemy Core tables columns as indexes for the subscript.

On top of:
```
row.type_id
1
```

You can now:
```
row['type_id']
1
row[models.t_table.c.type_id]
1
``` 

It calls asyncpg Record for every other method call not implemented here, so you can use row.keys() or row.values() or row_list = [ dict(p) for p in rows ], the last being useful for serialization for example.

Related to #32 