### PR TITLE
Upgrade to asyncpg 0.12.0.

### DIFF
--- a/asyncpgsa/connection.py
+++ b/asyncpgsa/connection.py
@@ -85,40 +85,46 @@ def compile_query(query, dialect=_dialect, inline=False):
         return new_query, new_params
 
 
-class SAConnection:
-    __slots__ = ('_connection', '_dialect')
+class SAConnection(connection.Connection):
+    # __slots__ = ('_dialect')
+    _dialect = None
 
-    def __init__(self, connection_: connection, *, dialect=None):
-        self._connection = connection_
-        if not dialect:
-            dialect = _dialect
-        self._dialect = dialect
+    # def __init__(self, connection_: connection, *, dialect=None):
+    #     self._connection = connection_
+    #     if not dialect:
+    #         dialect = _dialect
+    #     self._dialect = dialect
 
-    def __getattr__(self, attr, *args, **kwargs):
-        # getattr is only called when attr is NOT found
-        return getattr(self._connection, attr)
+    # def __getattr__(self, attr, *args, **kwargs):
+    #     # getattr is only called when attr is NOT found
+    #     return getattr(self._connection, attr)
+
+    def _execute(self, query, args, limit, timeout, return_status=False):
+        query, args = compile_query(query, dialect=self._dialect)
+        return super()._execute(query, args, limit, timeout,
+                                return_status=return_status)
 
     async def execute(self, script, *args, **kwargs) -> str:
-        script, params = compile_query(script, dialect=self._dialect)
-        result = await self._connection.execute(script, *params, *args, **kwargs)
+        # script, params = compile_query(script, dialect=self._dialect)
+        result = await super().execute(script, *args, **kwargs)
         return RecordGenerator(result)
 
     async def prepare(self, query, **kwargs):
-        query, params = compile_query(query, dialect=self._dialect)
-        return await self._connection.prepare(query, **kwargs)
+        # query, params = compile_query(query, dialect=self._dialect)
+        return await super().prepare(query, **kwargs)
 
     async def fetch(self, query, *args, **kwargs) -> list:
-        query, params = compile_query(query, dialect=self._dialect)
-        result = await self._connection.fetch(query, *params, *args, **kwargs)
+        # query, params = compile_query(query, dialect=self._dialect)
+        result = await super().fetch(query, *args, **kwargs)
         return RecordGenerator(result)
 
     async def fetchval(self, query, *args, **kwargs):
-        query, params = compile_query(query, dialect=self._dialect)
-        return await self._connection.fetchval(query, *params, *args, **kwargs)
+        # query, params = compile_query(query, dialect=self._dialect)
+        return await super().fetchval(query, *args, **kwargs)
 
     async def fetchrow(self, query, *args, **kwargs):
-        query, params = compile_query(query, dialect=self._dialect)
-        result = await self._connection.fetchrow(query, *params, *args, **kwargs)
+        # query, params = compile_query(query, dialect=self._dialect)
+        result = await super().fetchrow(query, *args, **kwargs)
         return Record(result)
 
     async def insert(self, query, *args, id_col_name: str = 'id', **kwargs):

--- a/asyncpgsa/pool.py
+++ b/asyncpgsa/pool.py
@@ -1,88 +1,26 @@
-from asyncpg.pool import Pool
+from functools import wraps
+
+import asyncpg
 
 from .transactionmanager import ConnectionTransactionContextManager
 from .connection import SAConnection
 
 
-class SAPool(Pool):
-    def __init__(self, *args, dialect=None, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.dialect = dialect
-
-    async def _new_connection(self, timeout=None):
-        con = await super()._new_connection()
-        self._connections.remove(con)
-        con = SAConnection.from_connection(con, dialect=self.dialect)
-        self._connections.add(con)
-        return con
-
-    def transaction(self, **kwargs):
-        return ConnectionTransactionContextManager(self, **kwargs)
-
-    def begin(self, **kwargs):
-        """ an alias for self.transaction() """
-        return self.transaction(**kwargs)
-
-
-def create_pool(dsn=None, *,
-                min_size=10,
-                max_size=10,
-                max_queries=50000,
-                setup=None,
-                init=None,
-                loop=None,
+@wraps(asyncpg.create_pool)
+def create_pool(*args,
                 dialect=None,
                 **connect_kwargs):
-    r"""Create a connection pool.
+    SAConnection._dialect = dialect
 
-    Can be used either with an ``async with`` block:
+    # dict is fine on the pool object as there is usually only one of them
+    # asyncpg.pool.Pool.__slots__ += ('__dict__',)
 
-    .. code-block:: python
-
-        async with asyncpgsa.create_pool(user='postgres',
-                                       command_timeout=60) as pool:
-            async with poll.acquire() as con:
-                await con.fetch('SELECT 1')
-
-    Or directly with ``await``:
-
-    .. code-block:: python
-
-        pool = await asyncpgsa.create_pool(user='postgres', command_timeout=60)
-        con = await poll.acquire()
-        try:
-            await con.fetch('SELECT 1')
-        finally:
-            await pool.release(con)
-
-    :param dialect: sqlalchemy postgres dialect
-    :param str dsn: Connection arguments specified using as a single string in
-                    the following format:
-                    ``postgres://user:pass@host:port/database?option=value``.
-
-    :param \*\*connect_kwargs: Keyword arguments for the
-                               :func:`~asyncpg.connection.connect` function.
-    :param int min_size: Number of connection the pool will be initialized
-                         with.
-    :param int max_size: Max number of connections in the pool.
-    :param int max_queries: Number of queries after a connection is closed
-                            and replaced with a new connection.
-    :param coroutine setup: A coroutine to initialize a connection right before
-                            it is returned from :meth:`~pool.Pool.acquire`.
-                            An example use case would be to automatically
-                            set up notifications listeners for all connections
-                            of a pool.
-    :param coroutine init: A coroutine to initialize a connection
-                            when it is created. An example use case would
-                            be to setup type codecs with
-                            set_builtin_type_codec() or set_type_codec()
-    :param loop: An asyncio event loop instance.  If ``None``, the default
-                 event loop will be used.
-    :return: An instance of :class:`~asyncpg.pool.Pool`.
-    """
-    return SAPool(dsn,
-                  min_size=min_size, max_size=max_size,
-                  max_queries=max_queries, loop=loop, setup=setup, init=init,
-                  dialect=dialect,
-                  **connect_kwargs)
+    # monkey patch pool to have some extra methods
+    def transaction(self, **kwargs):
+        return ConnectionTransactionContextManager(self, **kwargs)
+    asyncpg.pool.Pool.transaction = transaction
+    asyncpg.pool.Pool.begin = transaction
+    pool = asyncpg.create_pool(*args, connection_class=SAConnection,
+                               **connect_kwargs)
+    return pool
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-asyncpg~=0.11.0
+asyncpg~=0.12.0
 pytest
 pytest-asyncio
 pytest-capturelog>=0.7

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-asyncpg~=0.9.0
+asyncpg~=0.11.0
 pytest
 pytest-asyncio
 pytest-capturelog>=0.7

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name='asyncpgsa',
     version=__import__('asyncpgsa').__version__,
     install_requires=[
-        'asyncpg~=0.11.0',
+        'asyncpg~=0.12.0',
         'sqlalchemy',
     ],
     packages=['asyncpgsa', 'asyncpgsa.testing'],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name='asyncpgsa',
     version=__import__('asyncpgsa').__version__,
     install_requires=[
-        'asyncpg~=0.9.0',
+        'asyncpg~=0.11.0',
         'sqlalchemy',
     ],
     packages=['asyncpgsa', 'asyncpgsa.testing'],


### PR DESCRIPTION
Fixes #33. This is just restoring asyncpgsa 0.11.0 with a dependency on the latest asyncpg. asyncpg 0.12.0 includes the fix to MagicStack/asyncpg#155, which means returned Records are properly wrapped to allow columns to be accessed as an attribute.