### PR TITLE
Fixed #38, keep args in `_execute`

### DIFF
--- a/asyncpgsa/connection.py
+++ b/asyncpgsa/connection.py
@@ -100,7 +100,8 @@ class SAConnection(connection.Connection):
     #     return getattr(self._connection, attr)
 
     def _execute(self, query, args, limit, timeout, return_status=False):
-        query, args = compile_query(query, dialect=self._dialect)
+        query, compiled_args = compile_query(query, dialect=self._dialect)
+        args = tuple(compiled_args) + args
         return super()._execute(query, args, limit, timeout,
                                 return_status=return_status)
 

--- a/tests/test_pgsingleton.py
+++ b/tests/test_pgsingleton.py
@@ -128,6 +128,12 @@ async def test_fetchval():
     assert value == 6.0
 
 
+async def test_sql_with_arguments():
+    script = "SELECT $1::INT"
+    result = await pg.execute(script, 1)
+    assert bool(result)
+
+
 async def test_transaction():
     async with pg.transaction() as conn:
         for row in await conn.fetch(query):


### PR DESCRIPTION
Merged `compiled_args` and `args`.