### PR TITLE
Let it respect TypeDecorator processors for custom column types

### DIFF
--- a/asyncpgsa/connection.py
+++ b/asyncpgsa/connection.py
@@ -41,8 +41,14 @@ def _replace_keys(querystring, params, inline=False):
 def _get_keys(compiled):
     p = _compiled_pattern
     keys = re.findall(p, compiled.string)
+    processors = compiled._bind_processors
+    params = []
     try:
-        params = [(i, compiled.params[i]) for i in keys]
+        for key in keys:
+            processed_param = (processors[key](compiled.params[key])
+                               if key in processors
+                               else compiled.params[key])
+            params.append((key, processed_param))
     except KeyError as e:
         raise MissingParameterError('Parameter {} missing'.format(e))
     return params

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,13 +1,49 @@
+import enum
 import logging
 
 from asyncpgsa import connection
 import sqlalchemy as sa
+
 
 file_table = sa.Table(
     'meows', sa.MetaData(),
     sa.Column('id'),
     sa.Column('id_1'),
 )
+
+
+class NameBasedEnumType(sa.types.TypeDecorator):
+    impl = sa.types.Enum
+
+    def __init__(self, enum_cls, **opts):
+        assert issubclass(enum_cls, enum.Enum)
+        self._opts = opts
+        self._enum_cls = enum_cls
+        enums = (m.name for m in enum_cls)
+        super().__init__(*enums, **opts)
+
+    def process_bind_param(self, value, dialect):
+        return value.name if value else None
+
+    def process_result_value(self, value: str, dialect):
+        return self._enum_cls[value] if value else None
+
+    def copy(self):
+        return NameBasedEnumType(self._enum_cls, **self._opts)
+
+
+class FileTypes(enum.Enum):
+    TEXT = 0
+    PNG = 1
+    PDF = 2
+
+
+file_type_table = sa.Table(
+    'meows2', sa.MetaData(),
+    sa.Column('type', NameBasedEnumType(FileTypes)),
+    sa.Column('name', sa.String(length=128)),
+)
+
 
 async def test__replace_keys():
     ids = list(range(1, 10))
@@ -21,6 +57,7 @@ async def test__replace_keys():
                            '($2, $3, $4, $5, $6, $7, $8, $9, $10)'
     assert new_query[1] == [None, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
+
 async def test__replace_keys_colon():
     sql = sa.text('SELECT :id, my_date::DATE FROM users')
     params = {
@@ -32,6 +69,7 @@ async def test__replace_keys_colon():
     assert q == 'SELECT $1, my_date::DATE FROM users'
     assert p == [123]
 
+
 async def test__get_keys():
     ids = list(range(1, 10))
     query = file_table.update() \
@@ -39,6 +77,26 @@ async def test__get_keys():
         .where(file_table.c.id.in_(ids))
     compiled = query.compile(dialect=connection._dialect)
     connection._get_keys(compiled)
+
+
+async def test__get_keys_with_custom_column_type():
+    query = (file_type_table.insert()
+                            .values(type=FileTypes.PDF, name='abc'))
+    compiled = query.compile(dialect=connection._dialect)
+    params = dict(connection._get_keys(compiled))
+    assert not isinstance(params['type'], FileTypes)
+    assert isinstance(params['type'], str)
+    assert isinstance(params['name'], str)
+    assert params['type'] == 'PDF'  # stringified
+    assert params['name'] == 'abc'
+
+    query = (sa.select([file_type_table])
+               .where(file_type_table.c.type == FileTypes.TEXT))
+    compiled = query.compile(dialect=connection._dialect)
+    params = dict(connection._get_keys(compiled))
+    assert not isinstance(params['type_1'], FileTypes)
+    assert isinstance(params['type_1'], str)
+    assert params['type_1'] == 'TEXT'  # stringified
 
 
 async def test_compile_query(monkeypatch):


### PR DESCRIPTION
Currently asyncpgsa does not invoke `TypeDecorator` methods such as `process_bind_param()` in user-defined column data types. This is because SQLAlchemy does not expose public APIs to do it, unfortunately. For instance, [`aiopg` implements this manually](https://github.com/vir-mir/aiopg/blob/004dfa7f/aiopg/sa/connection.py#L88-L97).

This commit modifies `_get_keys()` function in connection.py in a similar, simplified way. It makes a simple `enum.Enum` column type class like below to work:

```
import enum
import sqlalchemy as sa
from sqlalchemy.types import Enum as SAEnum, TypeDecorator

class EnumType(TypeDecorator):
    impl = SAEnum

    def __init__(self, enum_cls, **opts):
        assert issubclass(enum_cls, enum.Enum)
        self._opts = opts
        self._enum_cls = enum_cls
        enums = (m.name for m in enum_cls)
        super().__init__(*enums, **opts)

    def process_bind_param(self, value, dialect):
        return value.name if value else None

    def process_result_value(self, value: str, dialect):
        return self._enum_cls[value] if value else None

    def copy(self):
        return EnumType(self._enum_cls, **self._opts)
```

Without this patch, I encounter errors like this:
```
File "/Users/joongi/Projects/Lablup/sorna-gateway/sorna/manager/registry.py", line 165, in update_instance
  await conn.execute(query)
File "/Users/joongi/Projects/Lablup/sorna-gateway/venv/lib/python3.6/site-packages/asyncpgsa/connection.py", line 103, in execute
  result = await self._connection.execute(script, *params, *args, **kwargs)
File "/Users/joongi/Projects/Lablup/sorna-gateway/venv/lib/python3.6/site-packages/asyncpg/connection.py", line 175, in execute
  True, timeout)
File "asyncpg/protocol/protocol.pyx", line 165, in bind_execute (asyncpg/protocol/protocol.c:55101)
asyncpg.exceptions.InvalidTextRepresentationError: invalid input value for enum agentstatus: "AgentStatus.ALIVE"
```