### PR TITLE
Fixup `create_pool` func: pass `dialect` kwarg correctly into `SAConnection`

### DIFF
--- a/asyncpgsa/pool.py
+++ b/asyncpgsa/pool.py
@@ -3,15 +3,17 @@ from functools import wraps
 import asyncpg
 
 from .transactionmanager import ConnectionTransactionContextManager
-from .connection import SAConnection
+from .connection import SAConnection as _SAConnection
 
 
 @wraps(asyncpg.create_pool)
 def create_pool(*args,
                 dialect=None,
                 **connect_kwargs):
+    class SAConnection(_SAConnection):
+        def __init__(self, *args, dialect=dialect, **kwargs):
+            super().__init__(*args, dialect=dialect, **kwargs)
     connection_class = SAConnection
-    connection_class._dialect = dialect
 
     # dict is fine on the pool object as there is usually only one of them
     # asyncpg.pool.Pool.__slots__ += ('__dict__',)
@@ -24,4 +26,3 @@ def create_pool(*args,
     pool = asyncpg.create_pool(*args, connection_class=connection_class,
                                **connect_kwargs)
     return pool
-


### PR DESCRIPTION
Hello!

I want to fix `dialect` kwarg, for now there are no way to specify custom dialect.