### PR TITLE
Run tests with docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.6-alpine
+
+RUN apk update && \
+    apk add \
+        gcc \
+        musl-dev \
+        postgresql-dev
+
+ADD . /repo
+RUN pip install -r /repo/dev-requirements.txt

--- a/contributing.md
+++ b/contributing.md
@@ -20,17 +20,33 @@ version you have locally
 
 # tests
 
-To run the tests you need a local postgres running. The easiest way is 
-to use docker-compose
+We use [pytest](https://docs.pytest.org/en/latest/) for tests.
+
+The easiest and recommended way to run test suite is to use docker-compose:
 
 ```
-docker-compose up -d
+docker-compose up --force-recreate --build
 ```
 
-should do it. Of course if you are running docker in a VM, like on a mac
-you will also have to port forward the host 5432 to the VM
+Otherwise, you need a local postgres running. It can be launched with docker-compose
+but it requires you to add `ports: "5432:5432"` to postgres service in docker-compose.yml.
+Then you can just launch:
+
+```
+docker-compose up -d postgres
+```
+
+Then, the tests can be run locally as:
+
+```
+pytest ./tests
+```
+
+Of course if you are running docker in a VM, like on a mac or windows 
+you will also have to forward port 5432 from VM to the host.
 
 You can also change the connection info in `tests/__init__.py`
 
 The tests just run generic postgres queries. Nothing is created/deleted, 
 so it should be safe if you also have other stuff in your local db.
+

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 asyncpg~=0.12.0
 pytest
 pytest-asyncio
-pytest-capturelog>=0.7
 sqlalchemy
 psycopg2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,25 @@
-postgres:
-  image: postgres
-  environment: 
-    POSTGRES_PASSWORD: password
-  ports:
-    - "5432:5432"
+version: "3"
+
+services:
+  tests:
+    build:
+      context: .
+    working_dir: /repo
+    command: pytest ./tests -s -vvv --log-level=DEBUG
+    depends_on:
+      - postgres
+    links:
+      - postgres
+    environment:
+      - DB_HOST=postgres
+      - DB_PORT=5432
+      - DB_NAME=postgres
+      - DB_USER=postgres
+      - DB_PASS=password
+  postgres:
+    image: postgres
+    hostname: postgres
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -1,5 +1,1 @@
-tests require a running postgres
-
-The easiest way is with docker compose
-
-`docker-compose up -d`
+See `tests` in [*contributing.md*](/contributing.md) for more information on testing.

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -125,9 +125,9 @@ async def test_compile_query_debug(caplog):
         .values(id=None) \
         .where(file_table.c.id.in_(ids))
 
-    with caplog.atLevel(logging.DEBUG, logger='asyncpgsa.query'):
+    with caplog.at_level(logging.DEBUG, logger='asyncpgsa.query'):
         results, _ = connection.compile_query(query)
-        msgs = [record.msg for record in caplog.records()]
+        msgs = [record.msg for record in caplog.records]
         assert results in msgs
 
 
@@ -139,7 +139,7 @@ async def test_compile_query_no_debug(caplog):
         .values(id=None) \
         .where(file_table.c.id.in_(ids))
 
-    with caplog.atLevel(logging.WARNING, logger='asyncpgsa.query'):
+    with caplog.at_level(logging.WARNING, logger='asyncpgsa.query'):
         results, _ = connection.compile_query(query)
-        msgs = [record.msg for record in caplog.records()]
+        msgs = [record.msg for record in caplog.records]
         assert results not in msgs


### PR DESCRIPTION
Makes docker-compose a way to set up clean environment and run tests.

Summary of the changes:
* Adds Dockerfile that builds alpine docker image with dependencies and requirements (alpine is a lightweight docker image)
* Updates tests to latest pytest version: pytest-capturelog has been merged to core and blacklisted, so I migrated tests to use the recommended approach
* Updates READMEs

I have provided some more info in the commit logs.