### PR TITLE
Added `get_dialect` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ docs/_build/
 # PyBuilder
 target/
 
+# mypy
+.mypy_cache/
+
 # IPython Notebook
 .ipynb_checkpoints
 
@@ -87,3 +90,8 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# VisualStudioCode #
+.vscode/*
+.history
+*.code-workspace

--- a/asyncpgsa/connection.py
+++ b/asyncpgsa/connection.py
@@ -5,13 +5,21 @@ from sqlalchemy.sql.dml import Insert as InsertObject, Update as UpdateObject
 
 from .log import query_logger
 
-_dialect = pypostgresql.dialect(paramstyle='pyformat')
-_dialect.implicit_returning = True
-_dialect.supports_native_enum = True
-_dialect.supports_smallserial = True  # 9.2+
-_dialect._backslash_escapes = False
-_dialect.supports_sane_multi_rowcount = True  # psycopg 2.0.9+
-_dialect._has_native_hstore = True
+
+def get_dialect(**kwargs):
+    dialect = pypostgresql.dialect(paramstyle='pyformat', **kwargs)
+
+    dialect.implicit_returning = True
+    dialect.supports_native_enum = True
+    dialect.supports_smallserial = True  # 9.2+
+    dialect._backslash_escapes = False
+    dialect.supports_sane_multi_rowcount = True  # psycopg 2.0.9+
+    dialect._has_native_hstore = True
+
+    return dialect
+
+
+_dialect = get_dialect()
 
 
 def execute_defaults(query):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to asyncpgsa's 
+Welcome to asyncpgsa's
 =====================================
 
 A python library wrapper around asyncpg for use with sqlalchemy.
@@ -69,8 +69,8 @@ PG Singleton
 ^^^^^^^^^^^^
 If you want the highest level of abstraction, you can can use the singleton object. This will create a pool for you.
 
-Init 
-++++ 
+Init
+++++
 Before you can run any queries you first have to initialize the pool
 
 .. code-block:: python
@@ -87,7 +87,7 @@ Before you can run any queries you first have to initialize the pool
     )
 
 Query
-+++++ 
++++++
 Query is for making read only select statements.
 This method will create a prepared statement for you and return a cursor object that will get a couple rows at a time from the database.
 This is great for select statements with lots of results.
@@ -190,7 +190,7 @@ Creating the pool
     	max_size=10
     )
 
-Transaction 
+Transaction
 +++++++++++
 The transaction context manager will establish a connection and start a transaction all at once. It returns the connection object. Commits and rollbacks will be handled for you.
 
@@ -264,6 +264,42 @@ json
 
          ...
 
+As another option you can initialize PostgreSQL dialect with custom JSON serializer and deserializer and pass it into `pg.init`
+
+.. code-block:: python
+
+    from asyncpgsa.connection import get_dialect
+
+    async def main():
+        dialect = get_dialect(
+            json_serializer=json.dumps,
+            json_deserializer=ujson.loads
+        )
+
+        await pg.init("postgresql://127.0.0.1/template0", dialect=dialect)
+
+        ...
+
+Also you can initialize pool with custom dialect
+
+.. code-block:: python
+
+    import asyncpgsa
+    from asyncpgsa.connection import get_dialect
+
+    async def main():
+        dialect = get_dialect(
+            json_serializer=json.dumps,
+            json_deserializer=ujson.loads
+        )
+
+        await asyncpgsa.create_pool(
+            dialect=dialect,
+            ...
+        )
+
+        ...
+
 
 Compile
 =======
@@ -328,4 +364,3 @@ And another where there are multiple queries
 
 .. toctree::
    :maxdepth: 2
-


### PR DESCRIPTION
Hi!

I'd like to add simple change. In my projects I need to pass custom JSON serializer and now I need to copy hole dialect initialization code into my source and I think it's a bit ugly and hard to support.

With my little change I can simplify my code:
```
import asyncpgsa
from asyncpgsa.connection import get_dialect

pool = await asyncpgsa.create_pool(
    dialect=get_dialect(json_serializer=MyCustomJsonSerializer),
    ...
)
```

All my changes are backward compatible. What do you think?