### PR TITLE
Add set_database_results() to the MockConnection class.

### DIFF
--- a/asyncpgsa/testing/mockconnection.py
+++ b/asyncpgsa/testing/mockconnection.py
@@ -9,9 +9,9 @@ completed_queries = []
 
 
 def __subclasscheck__(cls, subclass):
-        if subclass == MockConnection:
-            return True
-        return old_subclass_check(cls, subclass)
+    if subclass == MockConnection:
+        return True
+    return old_subclass_check(cls, subclass)
 
 old_subclass_check = ConnectionMeta.__subclasscheck__
 ConnectionMeta.__subclasscheck__ = __subclasscheck__

--- a/asyncpgsa/testing/mockconnection.py
+++ b/asyncpgsa/testing/mockconnection.py
@@ -33,6 +33,11 @@ class MockConnection:
         global results
         results = result
 
+    def set_database_results(self, *dbresults):
+        self.results = Queue()
+        for result in dbresults:
+            self.results.put_nowait(result)
+
     async def general_query(self, query, *args, **kwargs):
         completed_queries.append((query, *args, kwargs))
         return results.get_nowait()

--- a/asyncpgsa/testing/mockpgsingleton.py
+++ b/asyncpgsa/testing/mockpgsingleton.py
@@ -57,5 +57,3 @@ class MockQueryContextManager:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         pass
-
-

--- a/asyncpgsa/testing/mockpgsingleton.py
+++ b/asyncpgsa/testing/mockpgsingleton.py
@@ -16,7 +16,7 @@ class MockPG:
         self.__pool = MockSAPool(connection=self.connection)
 
     def get_completed_queries(self):
-        return self.connection.get_completed_queries
+        return self.connection.completed_queries
 
     def set_database_results(self, *results):
         self.connection.results = Queue()  # reset queue

--- a/asyncpgsa/testing/mockpool.py
+++ b/asyncpgsa/testing/mockpool.py
@@ -57,5 +57,3 @@ class MockSAPool(Pool):
 
     async def close(self):
         pass
-
-

--- a/asyncpgsa/testing/mockpreparedstmt.py
+++ b/asyncpgsa/testing/mockpreparedstmt.py
@@ -26,6 +26,3 @@ class MockCursor:
             return next(self.iterator)
         except StopIteration:
             raise StopAsyncIteration
-
-
-


### PR DESCRIPTION
If one isn't using MockPGSingleton, they have to directly manipulate the MockConnection results queue. I consider this a leaky abstraction because, if I use transactions, I must directly manipulate the `results` property on the connection object.

e.g.,

```python
pg = MockPg()
async with pg.transaction() as tx:
    pg.results.put_nowait(*result_items). # One shouldn't need to know that this is an asyncio.Queue
```

For this PR, I'm simply using the same convention that exists on the PGSingleton.

Additionally, I cleaned up some other parts of the mock code - including what I believe is a broken reference to the `completed_queries` accessor.

on-behalf-of: @sparkmeter <aru.sahni@sparkmeter.io>